### PR TITLE
docker-ce -> docker.io in run.bash

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -54,15 +54,15 @@ fi
 
 DOCKER_OPTS=
 
-# Get the current version of docker-ce
+# Get the current version of docker.io
 # Strip leading stuff before the version number so it can be compared
-DOCKER_VER=$(dpkg-query -f='${Version}' --show docker-ce | sed 's/[0-9]://')
+DOCKER_VER=$(dpkg-query -f='${Version}' --show docker.io | sed 's/[0-9]://')
 if dpkg --compare-versions 19.03 gt "$DOCKER_VER"
 then
     echo "Docker version is less than 19.03, using nvidia-docker2 runtime"
     if ! dpkg --list | grep nvidia-docker2
     then
-        echo "Please either update docker-ce to a version greater than 19.03 or install nvidia-docker2"
+        echo "Please either update docker.io to a version greater than 19.03 or install nvidia-docker2"
 	exit 1
     fi
     DOCKER_OPTS="$DOCKER_OPTS --runtime=nvidia"


### PR DESCRIPTION
docker-ce is now deprecated

I don't know about compatibility for people who installed the docker-ce before it was deprecated